### PR TITLE
Fixed reset not working after counting down to 0.

### DIFF
--- a/src/app/components/countdown/countdown.component.ts
+++ b/src/app/components/countdown/countdown.component.ts
@@ -44,7 +44,7 @@ export class CountdownComponent implements OnInit, AfterViewInit {
         return isCounting ? interval(1000) : of();
       }),
       scan((accumulatedValue, currentValue) => {
-        if (accumulatedValue === 0) return accumulatedValue;
+        if (accumulatedValue === 0 && currentValue !== null) return accumulatedValue;
         if (currentValue === null || !accumulatedValue) return this.d.getTotalSeconds();
         return --accumulatedValue;
       })


### PR DESCRIPTION
When the count down reaches 0, clicking the reset button does not reset the timer.